### PR TITLE
Update Lit decorator imports to avoid duplicate

### DIFF
--- a/frontend/src/about-view.ts
+++ b/frontend/src/about-view.ts
@@ -1,5 +1,5 @@
 import {css, html, LitElement, PropertyValues} from 'lit';
-import {customElement,property, state} from 'lit/decorators.js';
+import {customElement, property, state} from 'lit/decorators.js';
 import {registerTranslateConfig, translate, translateUnsafeHTML, use} from "lit-translate";
 
 registerTranslateConfig({

--- a/frontend/src/about-view.ts
+++ b/frontend/src/about-view.ts
@@ -1,7 +1,6 @@
 import {css, html, LitElement, PropertyValues} from 'lit';
-import {customElement} from 'lit/decorators.js';
+import {customElement,property, state} from 'lit/decorators.js';
 import {registerTranslateConfig, translate, translateUnsafeHTML, use} from "lit-translate";
-import {property, state} from "lit/decorators";
 
 registerTranslateConfig({
     loader: lang => fetch(`${lang}.json`).then(res => res.json())


### PR DESCRIPTION
Let's use a single import with `.js` extension which is required by Lit.